### PR TITLE
allow filtering by item tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.earthmc</groupId>
   <artifactId>HopperFilter</artifactId>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <packaging>jar</packaging>
 
   <name>HopperFilter</name>

--- a/src/main/java/net/earthmc/hopperfilter/listener/InventoryMoveItemListener.java
+++ b/src/main/java/net/earthmc/hopperfilter/listener/InventoryMoveItemListener.java
@@ -53,7 +53,7 @@ public class InventoryMoveItemListener implements Listener {
             case '*' -> itemName.contains(string); // Contains specified pattern
             case '^' -> itemName.startsWith(string); // Starts with specified pattern
             case '$' -> itemName.endsWith(string); // Ends with specified pattern
-            case '#' -> {
+            case '#' -> { // Item has specified tag
                 Tag<Material> tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, NamespacedKey.minecraft(string), Material.class);
                 yield tag != null && tag.isTagged(item.getType());
             }

--- a/src/main/java/net/earthmc/hopperfilter/listener/InventoryMoveItemListener.java
+++ b/src/main/java/net/earthmc/hopperfilter/listener/InventoryMoveItemListener.java
@@ -2,6 +2,11 @@ package net.earthmc.hopperfilter.listener;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+import org.bukkit.Tag;
 import org.bukkit.block.Hopper;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -34,7 +39,13 @@ public class InventoryMoveItemListener implements Listener {
             final String pattern = string.toLowerCase().strip();
             final int length = pattern.length();
 
-            if (pattern.startsWith("*") && pattern.endsWith("*")) { // Contains specified pattern
+            if(pattern.startsWith("#")) { // Filter by item tags, such as `villager_plantable_seeds`
+                String key = pattern.substring(1);
+                Tag<Material> tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, NamespacedKey.minecraft(key), Material.class);
+                if(tag != null) {
+                    if(tag.isTagged(item.getType())) return true;
+                }
+            } else if (pattern.startsWith("*") && pattern.endsWith("*")) { // Contains specified pattern
                 if (itemName.contains(pattern.substring(1, length - 1))) return true;
             } else if (pattern.startsWith("*")) { // Starts with specified pattern
                 if (itemName.startsWith(pattern.substring(1))) return true;

--- a/src/main/java/net/earthmc/hopperfilter/listener/InventoryMoveItemListener.java
+++ b/src/main/java/net/earthmc/hopperfilter/listener/InventoryMoveItemListener.java
@@ -2,6 +2,10 @@ package net.earthmc.hopperfilter.listener;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Tag;
 import org.bukkit.block.Hopper;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -49,6 +53,10 @@ public class InventoryMoveItemListener implements Listener {
             case '*' -> itemName.contains(string); // Contains specified pattern
             case '^' -> itemName.startsWith(string); // Starts with specified pattern
             case '$' -> itemName.endsWith(string); // Ends with specified pattern
+            case '#' -> {
+                Tag<Material> tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, NamespacedKey.minecraft(string), Material.class);
+                yield tag != null && tag.isTagged(item.getType());
+            }
             default -> false;
         };
     }


### PR DESCRIPTION
adds a new filtering option that lets you use item tags. for example, you could add the filter `#villager_plantable_seeds` to filter wheat seeds, potatos, carrots, beetroot seeds, torchflower seeds, and pitcher pods. works with all [the other item tags too](https://github.com/misode/mcmeta/tree/decd7c9d72d8329e4cf87b9d493cd90af108beec/data/minecraft/tags/items), of course :-)