### PR TITLE
Fix a memory leak and invalid key exception

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>net.earthmc</groupId>
   <artifactId>HopperFilter</artifactId>
-  <version>0.3.6</version>
+  <version>0.3.7</version>
   <packaging>jar</packaging>
 
   <name>HopperFilter</name>

--- a/src/main/java/net/earthmc/hopperfilter/listener/HopperRenameListener.java
+++ b/src/main/java/net/earthmc/hopperfilter/listener/HopperRenameListener.java
@@ -21,6 +21,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 import org.bukkit.inventory.ItemStack;
 
@@ -174,6 +175,16 @@ public class HopperRenameListener implements Listener {
         renameHopper(hopper, originalMessage);
 
         HOPPER_INTERACTIONS_TYPING.remove(player.getUniqueId());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        final UUID uuid = event.getPlayer().getUniqueId();
+
+        HOPPER_INTERACTIONS_TYPING.remove(uuid);
+        HOPPER_INTERACTIONS_ITEM.remove(uuid);
+        PREVIOUS_HOPPERS.remove(uuid);
+        NUM_CONSECUTIVE_HOPPER_INTERACTIONS.remove(uuid);
     }
 
     private void initiateHopperRename(final Player player, final Hopper hopper) {

--- a/src/main/java/net/earthmc/hopperfilter/listener/HopperRenameListener.java
+++ b/src/main/java/net/earthmc/hopperfilter/listener/HopperRenameListener.java
@@ -35,6 +35,8 @@ public class HopperRenameListener implements Listener {
     private static final Map<UUID, Hopper> PREVIOUS_HOPPERS = new ConcurrentHashMap<>();
     private static final Map<UUID, Integer> NUM_CONSECUTIVE_HOPPER_INTERACTIONS = new ConcurrentHashMap<>();
 
+    public static final Set<String> REMOVE_NAME_STRINGS = Set.of("null", "remove", "clear");
+
     @EventHandler
     public void onPlayerInteract(final PlayerInteractEvent event) {
         final Block clickedBlock = event.getClickedBlock();
@@ -221,7 +223,7 @@ public class HopperRenameListener implements Listener {
         instance.getServer().getRegionScheduler().run(instance, hopperLocation, task -> {
             if (!(hopperLocation.getBlock().getState() instanceof Hopper)) return;
 
-            final Component component = name.equals("null") || name.equals("remove") ? null : Component.text(name);
+            final Component component = REMOVE_NAME_STRINGS.contains(name) ? null : Component.text(name);
             hopper.customName(component);
             hopper.setTransferCooldown(20); // Simple fix to prevent dupes
 

--- a/src/main/java/net/earthmc/hopperfilter/listener/InventoryActionListener.java
+++ b/src/main/java/net/earthmc/hopperfilter/listener/InventoryActionListener.java
@@ -141,8 +141,7 @@ public class InventoryActionListener implements Listener {
     private boolean canItemPassPattern(final String pattern, final ItemStack item) {
         final String itemName = item.getType().getKey().getKey();
 
-        if (pattern.isEmpty() || pattern.equals(itemName))
-            return true;
+        if (pattern.isEmpty() || pattern.equals(itemName)) return true;
 
         final char prefix = pattern.charAt(0); // The character at the start of the pattern
         final String string = pattern.substring(1); // Anything after the prefix
@@ -153,8 +152,7 @@ public class InventoryActionListener implements Listener {
             case '$' -> itemName.endsWith(string); // Ends with specified pattern
             case '#' -> { // Item has specified tag
                 final NamespacedKey key = NamespacedKey.fromString(string);
-                if (key == null)
-                    yield false;
+                if (key == null) yield false;
 
                 Tag<Material> tag = Bukkit.getTag(Tag.REGISTRY_BLOCKS, key, Material.class);
                 if (tag == null) tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, key, Material.class);

--- a/src/main/java/net/earthmc/hopperfilter/listener/InventoryActionListener.java
+++ b/src/main/java/net/earthmc/hopperfilter/listener/InventoryActionListener.java
@@ -141,7 +141,8 @@ public class InventoryActionListener implements Listener {
     private boolean canItemPassPattern(final String pattern, final ItemStack item) {
         final String itemName = item.getType().getKey().getKey();
 
-        if (pattern.equals(itemName)) return true;
+        if (pattern.isEmpty() || pattern.equals(itemName))
+            return true;
 
         final char prefix = pattern.charAt(0); // The character at the start of the pattern
         final String string = pattern.substring(1); // Anything after the prefix
@@ -151,8 +152,12 @@ public class InventoryActionListener implements Listener {
             case '^' -> itemName.startsWith(string); // Starts with specified pattern
             case '$' -> itemName.endsWith(string); // Ends with specified pattern
             case '#' -> { // Item has specified tag
-                Tag<Material> tag = Bukkit.getTag(Tag.REGISTRY_BLOCKS, NamespacedKey.minecraft(string), Material.class);
-                if (tag == null) tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, NamespacedKey.minecraft(string), Material.class);
+                final NamespacedKey key = NamespacedKey.fromString(string);
+                if (key == null)
+                    yield false;
+
+                Tag<Material> tag = Bukkit.getTag(Tag.REGISTRY_BLOCKS, key, Material.class);
+                if (tag == null) tag = Bukkit.getTag(Tag.REGISTRY_ITEMS, key, Material.class);
 
                 yield tag != null && tag.isTagged(item.getType());
             }


### PR DESCRIPTION
Clears some maps when the player logs off, checks if the pattern is empty to avoid an error at charAt(0), and checks if the key is invalid (null) to avoid another exception